### PR TITLE
build: switch to Soldevelo container images (Bitnami access now paid)

### DIFF
--- a/hw10/docker-compose.yml
+++ b/hw10/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - spark
 
   kafka:
-    image: bitnami/kafka:4.0.0
+    image: soldevelo/kafka:4.0.0
     networks:
       - wiki-streams-tier
     ports:

--- a/hw8/docker-compose.yml
+++ b/hw8/docker-compose.yml
@@ -4,7 +4,7 @@ networks:
 
 services:
   kafka:
-    image: bitnami/kafka:4.0.0
+    image: soldevelo/kafka:4.0.0
     networks:
       - hw8-tier
     ports:


### PR DESCRIPTION
## Switch container base images to SolDevelo

Bitnami images now require a VMware Tanzu subscription (change effective **August 28, 2025**). This causes pipeline failures and added cost for teams that relied on the public registry.

[SolDevelo](https://hub.docker.com/u/soldevelo) provides drop-in replacements - same Debian-based images, same startup scripts, same environment-variable API - built openly from [SolDevelo/containers](https://github.com/SolDevelo/containers) and tagged to match Bitnami upstream.

## Image substitutions

- `bitnami/kafka:4.0.0` → [`soldevelo/kafka:4.0.0`](https://hub.docker.com/r/soldevelo/kafka)